### PR TITLE
feat: Add AWS Infrastructure as Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,28 @@
+# IDE
 .vscode/
+.idea/
+
+# Environment variables and sensitive data
 .env
+*.env
+!example.env
+*_credentials.csv
+*_accessKeys.csv
+
+# Node.js
 node_modules/
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+*.tfvars
+!terraform.example.tfvars
+*.tfplan
+.terraformrc
+terraform.rc
+.terraform.lock.hcl
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,28 +1,78 @@
-# n8n-compose
+# n8n Infrastructure as Code
 
-Docker Compose configuration for running n8n with PostgreSQL.
+This repository contains the infrastructure configuration for running n8n with PostgreSQL on AWS using Terraform.
 
 ## Prerequisites
 
-- Docker
-- Docker Compose
+- AWS Account and AWS CLI configured
+- Terraform installed
+- Docker and Docker Compose (for local development)
+- Domain name configured in Route53 (for SSL/HTTPS)
 
-## Usage
+## Setup Instructions
 
 1. Clone this repository
-2. Run `docker-compose up -d`
+2. Copy configuration files:
+   ```bash
+   cp example.env .env
+   cd terraform/environments/dev
+   cp terraform.example.tfvars terraform.tfvars
+   ```
+3. Update configuration:
+   - Edit `.env` with your domain, subdomain, timezone, and SSL email
+   - Edit `terraform.tfvars` with the same values
+   - Generate AWS key pair named "n8n-key-pair" for SSH access
+
+4. Initialize and apply Terraform:
+   ```bash
+   cd terraform/environments/dev
+   terraform init
+   terraform apply
+   ```
+
+## Configuration Files
+
+- `example.env`: Template for environment variables
+- `terraform.example.tfvars`: Template for Terraform variables
+- `.env`: Your actual environment configuration (not committed)
+- `terraform.tfvars`: Your actual Terraform configuration (not committed)
+
+## Infrastructure Components
+
+- VPC with public subnet
+- EC2 instance running n8n
+- PostgreSQL database using Docker
+- Nginx as reverse proxy
+- Automatic SSL certificate from Let's Encrypt
+
+## Security
+
+- SSL/HTTPS enabled by default
+- Security groups limiting access to necessary ports
+- Environment variables for sensitive data
+
+## Local Development
+
+For local development without AWS:
+
+1. Copy and configure .env:
+   ```bash
+   cp example.env .env
+   ```
+
+2. Start n8n locally:
+   ```bash
+   docker-compose up -d
+   ```
+
 3. Access n8n at http://localhost:5678
 
 ## Environment Variables
 
-All configuration is done through environment variables in the docker-compose.yml file.
+### Required Variables
+- `DOMAIN_NAME`: Your top-level domain
+- `SUBDOMAIN`: Subdomain for n8n (e.g., "n8n" for n8n.example.com)
+- `SSL_EMAIL`: Email for Let's Encrypt notifications
 
-### PostgreSQL
-- POSTGRES_USER=n8n
-- POSTGRES_PASSWORD=n8n
-- POSTGRES_DB=n8n
-
-### n8n
-- N8N_HOST=localhost
-- N8N_PORT=5678
-- N8N_PROTOCOL=http
+### Optional Variables
+- `GENERIC_TIMEZONE`: Timezone for n8n (default: UTC)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:latest

--- a/example.env
+++ b/example.env
@@ -1,0 +1,15 @@
+# DOMAIN_NAME and SUBDOMAIN together determine where n8n will be reachable from
+# The top level domain to serve from
+DOMAIN_NAME=example.com
+
+# The subdomain to serve from
+SUBDOMAIN=n8n
+
+# The above example serve n8n at: https://n8n.example.com
+
+# Optional timezone to set which gets used by Cron and other scheduling nodes
+# Default value if not set
+GENERIC_TIMEZONE=UTC
+
+# The email address to use for the TLS/SSL certificate creation
+SSL_EMAIL=your-email@example.com

--- a/terraform/environments/dev/env_to_tfvars.sh
+++ b/terraform/environments/dev/env_to_tfvars.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Path to your .env file
+ENV_FILE="../../../.env"
+TFVARS_FILE="terraform.tfvars"
+
+# Check if .env file exists
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: .env file not found at $ENV_FILE"
+    exit 1
+fi
+
+# Clear or create terraform.tfvars
+> "$TFVARS_FILE"
+
+# Convert .env to terraform.tfvars format
+while IFS= read -r line; do
+    # Skip comments and empty lines
+    if [[ $line =~ ^#.*$ ]] || [[ -z $line ]]; then
+        continue
+    fi
+
+    # Split the line into key and value
+    key=$(echo "$line" | cut -d'=' -f1)
+    value=$(echo "$line" | cut -d'=' -f2-)
+
+    # Convert environment variable names to terraform variable names
+    case "$key" in
+        "DOMAIN_NAME")
+            echo "domain_name = \"$value\"" >> "$TFVARS_FILE"
+            ;;
+        "SUBDOMAIN")
+            echo "subdomain = \"$value\"" >> "$TFVARS_FILE"
+            ;;
+        "GENERIC_TIMEZONE")
+            echo "timezone = \"$value\"" >> "$TFVARS_FILE"
+            ;;
+        "SSL_EMAIL")
+            echo "ssl_email = \"$value\"" >> "$TFVARS_FILE"
+            ;;
+    esac
+done < "$ENV_FILE"
+
+echo "Successfully created $TFVARS_FILE from $ENV_FILE"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,36 @@
+provider "aws" {
+  region = "ap-southeast-1"  # Singapore region
+}
+
+locals {
+  environment = "development"
+  name_prefix = "n8n-${local.environment}"
+}
+
+module "n8n" {
+  source = "../../modules/n8n"
+
+  name_prefix       = local.name_prefix
+  vpc_cidr         = "10.0.0.0/16"
+  subnet_cidr      = "10.0.1.0/24"
+  availability_zone = "ap-southeast-1a"
+  ami_id           = "ami-078c1149d8ad719a7"  # Ubuntu 22.04 LTS in ap-southeast-1
+  instance_type    = "t2.micro"
+  key_name         = "n8n-key-pair"
+
+  # Variables from .env file
+  domain_name = var.domain_name
+  subdomain   = var.subdomain
+  timezone    = var.timezone
+  ssl_email   = var.ssl_email
+
+  root_volume_size = 30
+  root_volume_type = "gp2"
+
+  common_tags = {
+    Project     = "n8n"
+    Environment = local.environment
+    Terraform   = "true"
+    Owner       = "DevOps"
+  }
+}

--- a/terraform/environments/dev/terraform.example.tfvars
+++ b/terraform/environments/dev/terraform.example.tfvars
@@ -1,0 +1,4 @@
+domain_name = "example.com"
+subdomain = "n8n"
+timezone = "UTC"
+ssl_email = "your-email@example.com"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,19 @@
+variable "domain_name" {
+  description = "Domain name for n8n"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "Subdomain for n8n"
+  type        = string
+}
+
+variable "timezone" {
+  description = "Timezone for n8n"
+  type        = string
+}
+
+variable "ssl_email" {
+  description = "Email for SSL certificate"
+  type        = string
+}

--- a/terraform/modules/n8n/main.tf
+++ b/terraform/modules/n8n/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# EC2 Instance
+resource "aws_instance" "n8n" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.n8n_subnet.id
+  vpc_security_group_ids = [aws_security_group.n8n_sg.id]
+  key_name      = var.key_name
+
+  root_block_device {
+    volume_size = var.root_volume_size
+    volume_type = var.root_volume_type
+  }
+
+  user_data = templatefile("${path.module}/templates/user_data.sh.tpl", {
+    domain_name = var.domain_name
+    subdomain   = var.subdomain
+    timezone    = var.timezone
+    ssl_email   = var.ssl_email
+  })
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-instance"
+  })
+}

--- a/terraform/modules/n8n/network.tf
+++ b/terraform/modules/n8n/network.tf
@@ -1,0 +1,47 @@
+# VPC and Network Configuration
+resource "aws_vpc" "n8n_vpc" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-vpc"
+  })
+}
+
+resource "aws_subnet" "n8n_subnet" {
+  vpc_id                  = aws_vpc.n8n_vpc.id
+  cidr_block             = var.subnet_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-subnet"
+  })
+}
+
+resource "aws_internet_gateway" "n8n_igw" {
+  vpc_id = aws_vpc.n8n_vpc.id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-igw"
+  })
+}
+
+resource "aws_route_table" "n8n_rt" {
+  vpc_id = aws_vpc.n8n_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.n8n_igw.id
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-rt"
+  })
+}
+
+resource "aws_route_table_association" "n8n_rta" {
+  subnet_id      = aws_subnet.n8n_subnet.id
+  route_table_id = aws_route_table.n8n_rt.id
+}

--- a/terraform/modules/n8n/outputs.tf
+++ b/terraform/modules/n8n/outputs.tf
@@ -1,0 +1,34 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.n8n.id
+}
+
+output "public_ip" {
+  description = "Public IP of the n8n instance"
+  value       = aws_instance.n8n.public_ip
+}
+
+output "public_dns" {
+  description = "Public DNS of the n8n instance"
+  value       = aws_instance.n8n.public_dns
+}
+
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.n8n_vpc.id
+}
+
+output "subnet_id" {
+  description = "ID of the subnet"
+  value       = aws_subnet.n8n_subnet.id
+}
+
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = aws_security_group.n8n_sg.id
+}
+
+output "n8n_url" {
+  description = "URL to access n8n"
+  value       = "https://${var.subdomain}.${var.domain_name}"
+}

--- a/terraform/modules/n8n/security.tf
+++ b/terraform/modules/n8n/security.tf
@@ -1,0 +1,28 @@
+# Security Group
+resource "aws_security_group" "n8n_sg" {
+  name        = "${var.name_prefix}-security-group"
+  description = "Security group for n8n instance"
+  vpc_id      = aws_vpc.n8n_vpc.id
+
+  dynamic "ingress" {
+    for_each = var.security_group_rules
+    content {
+      from_port   = ingress.value.port
+      to_port     = ingress.value.port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+      description = ingress.value.description
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-sg"
+  })
+}

--- a/terraform/modules/n8n/templates/user_data.sh.tpl
+++ b/terraform/modules/n8n/templates/user_data.sh.tpl
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+# Load environment variables
+cat > /etc/n8n.env << 'ENV'
+DOMAIN_NAME=${domain_name}
+SUBDOMAIN=${subdomain}
+GENERIC_TIMEZONE=${timezone}
+SSL_EMAIL=${ssl_email}
+ENV
+
+# Source environment variables
+set -a
+source /etc/n8n.env
+set +a
+
+# Install required packages
+apt-get update
+apt-get install -y apt-transport-https ca-certificates curl software-properties-common nginx certbot python3-certbot-nginx
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Configure Docker permissions
+usermod -aG docker ubuntu
+systemctl enable docker
+systemctl start docker
+
+# unix:///var/run/docker.sock
+sudo chmod 666 /var/run/docker.sock
+
+# Install Docker Compose
+curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+# Create n8n directory and configuration
+mkdir -p /opt/n8n
+cd /opt/n8n
+
+# Create environment file with proper values interpolated
+cat > /opt/n8n/.env << EOF
+DOMAIN_NAME=$DOMAIN_NAME
+SUBDOMAIN=$SUBDOMAIN
+GENERIC_TIMEZONE=$GENERIC_TIMEZONE
+DB_TYPE=postgresdb
+DB_POSTGRESDB_HOST=postgres
+DB_POSTGRESDB_PORT=5432
+DB_POSTGRESDB_DATABASE=n8n
+DB_POSTGRESDB_USER=n8n
+DB_POSTGRESDB_PASSWORD=n8n
+N8N_HOST=$DOMAIN_NAME
+N8N_PORT=5678
+N8N_PROTOCOL=https
+WEBHOOK_URL=https://$SUBDOMAIN.$DOMAIN_NAME/
+EOF
+
+# Create docker-compose.yml without environment variable interpolation
+cat > docker-compose.yml << 'COMPOSE'
+services:
+  postgres:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=n8n
+      - POSTGRES_PASSWORD=n8n
+      - POSTGRES_DB=n8n
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U n8n"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  n8n:
+    image: docker.n8n.io/n8nio/n8n
+    restart: always
+    ports:
+      - "127.0.0.1:5678:5678"
+    env_file:
+      - .env
+    volumes:
+      - n8n_data:/home/node/.n8n
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  n8n_data:
+COMPOSE
+
+# Set proper permissions
+chown -R ubuntu:ubuntu /opt/n8n
+chmod 600 /opt/n8n/.env
+
+# Configure Nginx
+cat > /etc/nginx/sites-available/n8n << EOF
+server {
+    server_name ${subdomain}.${domain_name};
+    
+    location / {
+        proxy_pass http://127.0.0.1:5678;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+        proxy_cache_bypass \$http_upgrade;
+    }
+}
+EOF
+
+# Enable the Nginx site
+ln -s /etc/nginx/sites-available/n8n /etc/nginx/sites-enabled/
+rm -f /etc/nginx/sites-enabled/default
+nginx -t && systemctl restart nginx
+
+# Check existing SSL certificate
+DOMAIN="$SUBDOMAIN.$DOMAIN_NAME"
+CERT_PATH="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
+KEY_PATH="/etc/letsencrypt/live/$DOMAIN/privkey.pem"
+
+if [ -f "$CERT_PATH" ] && [ -f "$KEY_PATH" ]; then
+    # Check certificate expiration (30 days threshold)
+    EXPIRY=$(openssl x509 -enddate -noout -in "$CERT_PATH" | cut -d= -f2)
+    EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s)
+    NOW_EPOCH=$(date +%s)
+    DAYS_REMAINING=$(( ($EXPIRY_EPOCH - $NOW_EPOCH) / 86400 ))
+    
+    if [ $DAYS_REMAINING -gt 30 ]; then
+        echo "Certificate for $DOMAIN is still valid for $DAYS_REMAINING days. Skipping renewal."
+    else
+        echo "Certificate for $DOMAIN will expire in $DAYS_REMAINING days. Proceeding with renewal."
+        certbot renew --quiet
+    fi
+else
+    echo "No existing certificate found for $DOMAIN. Obtaining new certificate."
+    certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos --email "$SSL_EMAIL" --redirect
+fi
+
+# Start n8n with proper error handling
+cd /opt/n8n
+docker-compose pull
+docker-compose down --volumes --remove-orphans
+sleep 5
+docker-compose up -d
+
+# Wait for services to be healthy
+attempt=1
+max_attempts=30
+until docker-compose ps | grep "n8n" | grep "Up" || [ $attempt -eq $max_attempts ]; do
+    echo "Waiting for n8n to start (attempt $attempt/$max_attempts)..."
+    sleep 10
+    attempt=$(( attempt + 1 ))
+done
+
+if [ $attempt -eq $max_attempts ]; then
+    echo "Failed to start n8n after $max_attempts attempts"
+    docker-compose logs
+    exit 1
+fi
+
+echo "n8n has started successfully"
+

--- a/terraform/modules/n8n/variables.tf
+++ b/terraform/modules/n8n/variables.tf
@@ -1,0 +1,117 @@
+variable "name_prefix" {
+  description = "Prefix to use for resource names"
+  type        = string
+  default     = "n8n"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_cidr" {
+  description = "CIDR block for subnet"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "availability_zone" {
+  description = "Availability zone for the subnet"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instance"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "Instance type for EC2 instance"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "key_name" {
+  description = "Name of the SSH key pair"
+  type        = string
+}
+
+variable "root_volume_size" {
+  description = "Size of the root volume in GB"
+  type        = number
+  default     = 30
+}
+
+variable "root_volume_type" {
+  description = "Type of the root volume"
+  type        = string
+  default     = "gp2"
+}
+
+variable "domain_name" {
+  description = "Domain name for n8n"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "Subdomain for n8n"
+  type        = string
+}
+
+variable "timezone" {
+  description = "Timezone for n8n"
+  type        = string
+  default     = "Asia/Ho_Chi_Minh"
+}
+
+variable "ssl_email" {
+  description = "Email for SSL certificate"
+  type        = string
+}
+
+variable "security_group_rules" {
+  description = "List of security group rules"
+  type = list(object({
+    port        = number
+    protocol    = string
+    cidr_blocks = list(string)
+    description = string
+  }))
+  default = [
+    {
+      port        = 22
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "SSH access"
+    },
+    {
+      port        = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTP access"
+    },
+    {
+      port        = 443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTPS access"
+    },
+    {
+      port        = 5678
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "n8n webhook access"
+    }
+  ]
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default = {
+    Project     = "n8n"
+    Environment = "production"
+    Terraform   = "true"
+  }
+}


### PR DESCRIPTION
## Changes
- Add Terraform configuration for AWS infrastructure
- Add Docker Compose for local development
- Add example environment files
- Update gitignore for sensitive data
- Update README with setup instructions

## Features
- Infrastructure as Code using Terraform
- VPC with public subnet
- EC2 instance with n8n
- PostgreSQL using Docker
- Nginx as reverse proxy
- Automatic SSL with Let's Encrypt
- Environment-based configuration
- Local development support

## Testing Done
- Successfully created infrastructure in AWS
- Verified n8n access via HTTPS
- Tested local development setup
- Validated environment configuration

## Additional Notes
- AWS key pair named "n8n-key-pair" required
- Domain must be configured in Route53
- Sensitive data properly excluded from git